### PR TITLE
Fix of SST interpolation and masking

### DIFF
--- a/metgrid/METGRID.TBL.ARW
+++ b/metgrid/METGRID.TBL.ARW
@@ -750,10 +750,12 @@ mpas_name=uReconstructMeridional
         fill_lev=200100:const(-1.E30)
 ========================================
 name=SST
-        interp_option=sixteen_pt+four_pt
+        interp_option=sixteen_pt+four_pt+wt_average_4pt+wt_average_16pt+search
         fill_missing=0.
         missing_value=-1.E30
         flag_in_output=FLAG_SST
+        masked=land
+        interp_mask=LANDSEA(1)
 ========================================
 name=QV
 mpas_name=qv


### PR DESCRIPTION
This adds interpolation options and land masking for SST variable in METGRID.TBL.ARW.
This fix improves representation of SST along the coastlines, and removes the artefacts related to the mask from the forcing data in wrf output files.