### PR TITLE
Fix: WPS uses deprecated version of JasPer interface

### DIFF
--- a/ungrib/src/ngl/g2/dec_jpeg2000.c
+++ b/ungrib/src/ngl/g2/dec_jpeg2000.c
@@ -68,6 +68,7 @@
     jas_image_cmpt_t cmpt,*pcmpt;
     char *opts=0;
     jas_matrix_t *data;
+    int fmt_id = 0; // The new format ID variable
 
 /*    jas_init(); */
 
@@ -77,12 +78,25 @@
 
     jpcstream=jas_stream_memopen(injpc,*bufsize);
 
+// --- START of MODIFIED BLOCK ---
+
+/*
+ * Get the format identifier for JPEG 2000 Code Stream (jpc).
+ */
+    fmt_id = jas_image_getfmt("jpc");
+    if (fmt_id < 0) {
+        printf("jas_image_getfmt failed for 'jpc'\n");
+        return -3; // Or another appropriate error code
+    }
+
+/*
+
 /*   
  *     Decode JPEG200 codestream into jas_image_t structure.
  */      
-    image=jpc_decode(jpcstream,opts);
+    image=jas_image_decode(jpcstream,fmt_id,opts);
     if ( image == 0 ) {
-       printf(" jpc_decode return = %d \n",ier);
+       printf(" jas_image_decode return = %d \n",ier);
        return -3;
     }
     

--- a/ungrib/src/ngl/g2/enc_jpeg2000.c
+++ b/ungrib/src/ngl/g2/enc_jpeg2000.c
@@ -178,9 +178,9 @@ int enc_jpeg2000(unsigned char *cin,g2int *pwidth,g2int *pheight,g2int *pnbits,
 /*
  *     Encode image.
  */
-    ier=jpc_encode(&image,jpcstream,opts);
+    ier=jas_image_encode(&image,jpcstream,opts);
     if ( ier != 0 ) {
-       printf(" jpc_encode return = %d \n",ier);
+       printf(" jas_image_encode return = %d \n",ier);
        return -3;
     }
 /*


### PR DESCRIPTION
Fix: WPS uses a deprecated JasPer interface. These modifications maintain compatibility with older JasPer versions.

https://github.com/wrf-model/WPS/issues/207
https://github.com/stefan-wolfsheimer/easybuild-easyconfigs/blob/a535132221cae31c20e1ba8f2256be80b3c6ecb3/easybuild/easyconfigs/w/WPS/WPS-4.6.0_fix_jasper_decode.patch